### PR TITLE
Stops Camera from Moving Twice

### DIFF
--- a/src/accessories/moveCamera.js
+++ b/src/accessories/moveCamera.js
@@ -26,8 +26,6 @@ const MoveCameraSwitch = class extends Accessory {
 
   switchStateChanged(newState, callback) {
     this.log('Moving Camera Motor')
-    // Double event to increase the speed
-    this.publishToMQTT('/motors/' + this.axis + '/set', this.direction)
     this.publishToMQTT('/motors/' + this.axis + '/set', this.direction)
     callback()
     this.updateState()


### PR DESCRIPTION
Per issue #24 the camera moves twice when it should only move once.
The original code talks about "speeding up" movement, but in actuality, this is not technically speeding up the movement (but a modification of the distance travelled instead) as there is no way to make the motors inside the camera move faster. I think this should be removed because as a user I am expecting the camera to move in increments that are the same as the default distance and not double the distance.